### PR TITLE
Child process options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Next, in your express server file, insert the following:
 
 const app = require('express')();
 const woven = require('woven-js');
-const functions = require(/* 'path to your functions file' */);
+const functionsPath = /* 'path to your functions file' */;
 
-woven.configure(functions, { /* client options */ });
+woven.configure(functionsPath, { /* client options */ });
 app.use(woven.optimize);
 
 ```
@@ -83,7 +83,7 @@ module.exports = { funcOne, funcTwo };
 The `woven.configure()` method links the back end with the project's pure functions.
 
 ```javascript
-woven.configure(functions, { /* client options */ });
+woven.configure(functionsPath, { /* client options */ });
 ```
 The options object accessible through the configure method also allows for developer customizations:
  

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The options object accessible through the configure method also allows for devel
   alwaysClient: false,
   alwaysServer: false,
   dynamicMax: 500,
-  execSyncFilePath: '',
   fallback: 'server',
   maxChildThreads: os.cpus().length,
   maxWorkerThreads: 12,

--- a/README.md
+++ b/README.md
@@ -88,14 +88,18 @@ woven.configure(functionsPath, { /* client options */ });
 The options object accessible through the configure method also allows for developer customizations:
  
 ```javascript
-module.exports = {
+{
   alwaysClient: false,
   alwaysServer: false,
-  dynamicMax: 10000,
+  dynamicMax: 500,
+  execSyncFilePath: '',
   fallback: 'server',
-  maxThreads: 12,
+  maxChildThreads: os.cpus().length,
+  maxWorkerThreads: 12,
   pingSize: 'small',
-}
+  useChildProcess: true,
+  useWebWorkers: true,
+};
 ```
 
 #### Developer Customization Options:
@@ -106,9 +110,13 @@ module.exports = {
 
   - **fallback:** In the event that the optimization process fails, WovenJS will route to the fallback assigned here. Unless modified by the developer the default fallback is to process on the server.
 
-  - **maxThreads:** A developer override to set the maximum # of threads that can be created for a given client (thread number corrosponds with the number of generated Web Workers).
+  - **maxWorkerThreads:** A developer override to set the maximum # of Web Worker threads that can be created for a every client.
+
+  - **maxChildThreads:** A developer override to set the maximum # of child process threads that can be run concurrently on the serer (defaults to number of CPU's).
 
   - **pingSize:** Use this property to set an exact size for the dynamic ping data in bytes or choose between WovenJS's preset options: `'tiny'`(100bytes), `'small'`(4kB), `'medium'`(50kB), `'large'`(400kB), or `'huge'`(1MB).
+
+  - **useChildProcess/useWebWorkers:** Use these properties to turn on or off using child processes on the server or Web Workers on the client. Default for both is true.
 
   Make sure that your server/application can handle the larger data transfer (400KB-1MB) before using the large/huge ping size presets.
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woven-js",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woven-js",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "intelligent multi-threading and server processing",
   "main": "index.js",
   "scripts": {

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -1,69 +1,66 @@
-function WorkerThread(pool, WorkerFile) {
-  this.pool = pool;
-  this.workerTask = {};
-  const _this = this;
-
-  function dummyCallback(event) {
-    _this.workerTask.callback(event.data);
-    _this.pool.freeWorkerThread(_this); // changed from this to _this
-    // terminates current worker thread - this refers to worker, _this refers to workerThread
-    this.terminate();
+class WorkerThread {
+  constructor(pool, WorkerFile) {
+    this.pool = pool;
+    this.WorkerFile = WorkerFile;
   }
 
-  function dummyErrorCallback(event) {
-    _this.workerTask.errorCallback(`${event.message}\nerror in worker at line ${event.lineno} in ${event.filename}`);
-    _this.pool.freeWorkerThread(_this);
-    this.terminate();
-  }
-
-  this.run = function run(workerTask) {
-    this.workerTask = workerTask;
-    if (this.workerTask.funcName !== null) {
-      const worker = new WorkerFile();
-      worker.addEventListener('message', dummyCallback, false);
-      worker.addEventListener('error', dummyErrorCallback, false);
+  run(workerTask) {
+    if (workerTask.funcName) {
+      const worker = new this.WorkerFile();
+      worker.addEventListener('message', (event) => {
+        workerTask.callback(event.data);
+        this.pool.freeWorkerThread(this);
+        worker.terminate();
+      });
+      worker.addEventListener('error', (event) => {
+        workerTask.errorCallback(`${event.message}\nerror in worker at line ${event.lineno} in ${event.filename}`);
+        this.pool.freeWorkerThread(this);
+        worker.terminate();
+      });
       worker.postMessage({ funcName: workerTask.funcName, payload: workerTask.payload });
+    } else {
+      console.error('invalid function name passed to worker pool');
+      this.pool.freeWorkerThread(this);
     }
-  };
-
-  this.run.bind(this);
+  }
 }
 
-function Pool(size, WorkerFile) {
-  this.taskQueue = [];
-  this.workerQueue = [];
-  this.poolSize = size;
+class Pool {
+  constructor(size, WorkerFile) {
+    this.taskQueue = [];
+    this.workerQueue = [];
+    this.WorkerFile = WorkerFile;
+    this.size = size;
+  }
 
-  this.addWorkerTask = function addWorkerTask(workerTask) {
+  addWorkerTask(workerTask) {
     if (this.workerQueue.length > 0) {
       const workerThread = this.workerQueue.shift();
       workerThread.run(workerTask);
     } else this.taskQueue.push(workerTask);
-  };
+  }
 
-  this.init = function init() {
-    for (let i = 0; i < this.poolSize; i += 1) {
-      this.workerQueue.push(new WorkerThread(this, WorkerFile));
+  init() {
+    for (let i = 0; i < this.size; i += 1) {
+      this.workerQueue.push(new WorkerThread(this, this.WorkerFile));
     }
-  };
+  }
 
-  this.freeWorkerThread = function freeWorkerThread(workerThread) {
+  freeWorkerThread(workerThread) {
     if (this.taskQueue.length > 0) {
       const workerTask = this.taskQueue.shift();
       workerThread.run(workerTask);
     } else this.workerQueue.push(workerThread);
-  };
-
-  this.addWorkerTask.bind(this);
-  this.init.bind(this);
-  this.freeWorkerThread.bind(this);
+  }
 }
 
-function WorkerTask(funcName, payload, callback, errorCallback) {
-  this.funcName = funcName;
-  this.payload = payload;
-  this.callback = callback;
-  this.errorCallback = errorCallback;
+class WorkerTask {
+  constructor(funcName, payload, callback, errorCallback) {
+    this.funcName = funcName;
+    this.payload = payload;
+    this.callback = callback;
+    this.errorCallback = errorCallback;
+  }
 }
 
 module.exports = { Pool, WorkerTask };

--- a/src/configure.js
+++ b/src/configure.js
@@ -88,15 +88,22 @@ module.exports = function configureWrapper(options) {
           break;
         case 'functionsPath':
           throw new Error('Set functions filepath in first argument of configure function.');
-        case 'maxThreads':
+        case 'maxChildThreads':
+          if (typeof userOptions[field] !== 'number') throw new Error(`${field} - incorrect data type.`);
+          break;
+        case 'maxWorkerThreads':
           if (typeof userOptions[field] !== 'number') throw new Error(`${field} - incorrect data type.`);
           break;
         case 'pingSize':
           if (typeof userOptions[field] !== 'number' && !(userOptions[field] in pingOptions)) throw new Error(`${field} - incorrect data type.`);
           if (userOptions[field] > 10000000) throw new Error('pingSize is too large; should be 10M bytes or less');
           break;
-        case 'stringPing':
-          throw new Error(`${field} is not a configurable option`);
+        case 'useChildProcess':
+          if (typeof userOptions[field] !== 'boolean') throw new Error(`${field} - incorrect data type.`);
+          break;
+        case 'useWebWorkers':
+          if (typeof userOptions[field] !== 'boolean') throw new Error(`${field} - incorrect data type.`);
+          break;
         default:
           throw new Error(`${field} is not a configurable option`);
       }

--- a/src/configure.js
+++ b/src/configure.js
@@ -47,7 +47,7 @@ module.exports = function configureWrapper(options) {
 
     // create path for woven child process file and exec sync file
     const childProcessFilePath = `${functionsPath.slice(0, -3)}_woven_child_process.js`;
-    const execSyncFilePath = `${functionsPath.slice(0, -3)}_woven_exec_file_sync.js`;
+    const execSyncFilePath = `${functionsPath.slice(0, -3)}_woven_exec_sync.js`;
 
     // string to append to woven_child_process file
     const childProcessFileString = `const functions = require('${functionsPath}');

--- a/src/connect.js
+++ b/src/connect.js
@@ -18,7 +18,7 @@ module.exports = function connectWrapper(optimal, Pool, performance) {
           alwaysClient: data.alwaysClient,
         };
         optimal.serverDefaults = false;
-        if (data.alwaysServer === true) {
+        if (data.alwaysServer === true || !window.Worker) {
           optimal.location = 'server';
           optimal.clientDefaults = false;
           return;

--- a/src/connect.js
+++ b/src/connect.js
@@ -13,12 +13,15 @@ module.exports = function connectWrapper(optimal, Pool, performance) {
           browser: null,
           missingDeviceInfo: false,
           dynamicMax: data.dynamicMax,
-          maxThreads: data.maxThreads,
+          maxWorkerThreads: data.maxWorkerThreads,
           fallback: data.fallback,
           alwaysClient: data.alwaysClient,
         };
         optimal.serverDefaults = false;
-        if (data.alwaysServer === true || !window.Worker) {
+        // If useWebWorkers flag is false temporary workaround is to run functions on
+        // the server. Ultimately should find another way to run functions on the client's
+        // single thread instead of using web workers.
+        if (data.alwaysServer === true || data.useWebWorkers === false || !window.Worker) {
           optimal.location = 'server';
           optimal.clientDefaults = false;
           return;

--- a/src/options.js
+++ b/src/options.js
@@ -1,10 +1,15 @@
+const os = require('os');
+
 module.exports = {
   alwaysClient: false,
   alwaysServer: false,
   dynamicMax: 500,
   fallback: 'server',
   functions: null,
-  maxThreads: 12,
+  maxChildThreads: os.cpus().length,
+  maxWorkerThreads: 12,
   pingSize: 100,
   stringPing: null,
+  useChildProcess: true,
+  useWebWorkers: true,
 };

--- a/src/options.js
+++ b/src/options.js
@@ -4,6 +4,7 @@ module.exports = {
   alwaysClient: false,
   alwaysServer: false,
   dynamicMax: 500,
+  execSyncFilePath: '',
   fallback: 'server',
   functions: null,
   maxChildThreads: os.cpus().length,

--- a/src/performance.js
+++ b/src/performance.js
@@ -26,7 +26,9 @@ function combinedOptimization(clientData, optimal) {
 
   function threadCheck() {
     if (clientData.threads) {
-      if (clientData.threads > clientData.maxThreads) clientData.threads = clientData.maxThreads;
+      if (clientData.threads > clientData.maxWorkerThreads) {
+        clientData.threads = clientData.maxWorkerThreads;
+      }
       if (clientData.browser === 'Chrome') {
         if (clientData.threads > 25) optimal.threads = 25;
         else optimal.threads = clientData.threads;
@@ -61,10 +63,10 @@ function combinedOptimization(clientData, optimal) {
   //   if (clientData.missingDeviceInfo === true) {
   //     console.log("Warning: missing client device data");
   //     optimal.location = clientData.fallback;
-  //   } else if (clientData.maxThreads > ideal[clientData.browser]) {
+  //   } else if (clientData.maxWorkerThreads > ideal[clientData.browser]) {
   //     optimal.threads = ideal[clientData.browser];
   //   } else {
-  //     optimal.threads = clientData.maxThreads;
+  //     optimal.threads = clientData.maxWorkerThreads;
   //   }
   //   console.log('will be processed here: ', optimal.location);
   // }


### PR DESCRIPTION
- README: update with minor API changes
- Pool.js: use ES6 class syntax
- configure.js:
   - create file to be read by child_process.execSync in case dev does not want to use child_processes on the sever
   - reconfigure options loop slightly based on new options
- options.js
   - add options to turn off using Web Workers or child processes
   - add option to control max number of child_process threads
- connect.js - minor changes based on new options
- optimize.js - server process now handles both child_process processing (using ChildPool.js) and synchronous single-threaded processing (using child_process.execSync)
- performance.js - minor changes based on new options